### PR TITLE
allow re edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - fix: config location was set to the sample by mistake #27 0.6.0.dev2
 - Added console.log to print a message when no config file is
   found #29 0.6.0.dev4
+- Add `get_jinja_env()` and support for templating and editing prompts in
+  `prompts.py` #30 0.6.0dev5
 
 ## 0.5.0
 

--- a/lockhart/cli/history.py
+++ b/lockhart/cli/history.py
@@ -1,5 +1,5 @@
-from rich.console import Console
 import typer
+from rich.console import Console
 
 from lockhart.cli.common import verbose_callback
 from lockhart.history import load_history

--- a/lockhart/cli/prompt.py
+++ b/lockhart/cli/prompt.py
@@ -1,5 +1,5 @@
-from rich.console import Console
 import typer
+from rich.console import Console
 
 from lockhart import prompts
 from lockhart.cli.common import verbose_callback

--- a/lockhart/jinja_env.py
+++ b/lockhart/jinja_env.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+import jinja2
+
+
+def get_jinja_env():
+    env = jinja2.Environment()
+    env.globals["read_text"] = lambda file: f"## {file}\n{Path(file).read_text()}"
+    return env

--- a/lockhart/prompts.py
+++ b/lockhart/prompts.py
@@ -1,14 +1,13 @@
 import copy
-from datetime import datetime
 import os
-from pathlib import Path
 import subprocess
 import sys
 import tempfile
 import time
+from datetime import datetime
+from pathlib import Path
 from typing import Optional, Union
 
-from jinja2 import Template
 import openai
 import tomlkit
 

--- a/lockhart/prompts.py
+++ b/lockhart/prompts.py
@@ -15,6 +15,7 @@ import tomlkit
 from lockhart.config import config
 from lockhart.console import console
 from lockhart.history import load_history, save_history
+from lockhart.jinja_env import get_jinja_env
 
 
 def load_prompt(prompt: str) -> dict:
@@ -56,7 +57,7 @@ def run_prompt(
     prompt = template_prompt(prompt, text)
 
     if edit:
-        prompt = edit_prompt(prompt)
+        return edit_prompt(prompt)
 
     if prompt is None:
         return "prompt quit"
@@ -68,7 +69,13 @@ def run_prompt(
     console.log("prompt: ", prompt)
     console.log("running completion")
     # response = openai.Completion.create(**prompt)
-    api = getattr(openai, prompt.pop("api"))
+    if prompt.get("api", None):
+        api = getattr(openai, prompt.pop("api"))
+    elif hasattr(prompt, "prompt"):
+        api = getattr(openai, "Completion")
+    else:
+        api = getattr(openai, "Edit")
+
     response = api.create(**prompt)
     text = response["choices"][0]["text"]
     history = load_history()
@@ -89,7 +96,7 @@ def template_prompt(prompt: dict, text: str) -> dict:
         console.log(f"templating {key}: {prompt[key]}")
 
         if isinstance(prompt[key], str):
-            template = Template(prompt[key])
+            template = get_jinja_env().from_string(prompt[key])
             value = template.render(input=input, text=text)
             prompt.update(
                 {
@@ -106,7 +113,7 @@ def edit_prompt(prompt: dict) -> dict:
     editor = os.environ.get("EDITOR", "vim")
     console.log(f"editing prompt with {editor}")
     file = tempfile.NamedTemporaryFile(prefix="lockhart", suffix=".toml")
-    file.write(tomlkit.dumps(prompt).encode())
+    file.write(("# edit = true\n" + tomlkit.dumps(prompt)).encode())
     file.seek(0)
     st_mtime = os.stat(file.name).st_mtime  # create time by lockhart
     initial_time = time.time()
@@ -124,7 +131,9 @@ def edit_prompt(prompt: dict) -> dict:
 
     prompt = tomlkit.loads(Path(file.name).read_text())
     console.log(f"updated prompt\n{prompt}")
-    return prompt
+    dry_run = bool(prompt.pop("dry_run", False))
+    edit = bool(prompt.pop("edit", False))
+    return run_prompt(prompt, dry_run=dry_run, edit=edit)
 
 
 def list_args(func: callable):


### PR DESCRIPTION
- Add Jinja Environment to Lockhart project
- Add support for Jinja templating and editing of prompts

This pr adds a new file, `lockhart/jinja_env.py`, which provides a function to
get a Jinja2 environment. This environment is used to template the prompt
before it is sent to OpenAI. Additionally, the `lockhart/prompts.py` file has
been updated to use the new Jinja2 environment and to add support for editing
prompts with
